### PR TITLE
Add support for python3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         include:
           - python-version: 3.7
             tox-py: py37
@@ -22,6 +22,8 @@ jobs:
             tox-py: py38
           - python-version: 3.9
             tox-py: py39
+          - python-version: 3.10
+            tox-py: py310
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -104,7 +106,7 @@ jobs:
         fail-fast: false
         matrix:
           #python-version: [3.6]
-          python-version: [3.6, 3.9]
+          python-version: [3.6, 3.9, 3.10]
           it-backend: [local, s3, gcs, minio, azure]
           # IBM not included by default due to lite plan quota being easily exceeded
           #it-backend: [local, s3, gcs, minio, ibm, azure]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         include:
           - python-version: 3.7
             tox-py: py37
@@ -22,7 +22,7 @@ jobs:
             tox-py: py38
           - python-version: 3.9
             tox-py: py39
-          - python-version: 3.10
+          - python-version: "3.10"
             tox-py: py310
     runs-on: ubuntu-18.04
     steps:
@@ -106,7 +106,7 @@ jobs:
         fail-fast: false
         matrix:
           #python-version: [3.6]
-          python-version: [3.6, 3.9, 3.10]
+          python-version: [3.6, 3.9, "3.10"]
           it-backend: [local, s3, gcs, minio, azure]
           # IBM not included by default due to lite plan quota being easily exceeded
           #it-backend: [local, s3, gcs, minio, ibm, azure]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lockfile>=0.12.2
 cryptography<=3.3.2,>=2.5
 pycryptodome>=3.9.9
 retrying>=1.3.3
-ssh2-python==0.22.0
+ssh2-python==0.27.0
 ssh-python>=0.6.0
 parallel-ssh==2.2.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         'pycryptodome>=3.9.9',
         'retrying>=1.3.3',
         'parallel-ssh==2.2.0',
-        'ssh2-python==0.22.0',
+        'ssh2-python==0.27.0',
         'ssh-python>=0.6.0',
         'requests==2.22.0',
         'protobuf>=3.12.0',


### PR DESCRIPTION
Ensure Medusa can run on Python 3.10 (Ubuntu 22.04)